### PR TITLE
chore(ci): add GitHub Actions workflow for Laravel and Node.js build, lint, test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,13 +14,11 @@ jobs:
         image: mysql:8
         env:
           MYSQL_DATABASE: zipp
-          MYSQL_USER: root
-          MYSQL_PASSWORD: root
-          MYSQL_ROOT_PASSWORD:  ${{ secrets.SQL_SECRET }}
+          MYSQL_ROOT_PASSWORD: ${{ secrets.SQL_SECRET }}
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -p${MYSQL_ROOT_PASSWORD}"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
@@ -52,7 +50,7 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_PORT: 3306
           DB_USERNAME: root
-          DB_PASSWORD: root
+          DB_PASSWORD: ${{ secrets.SQL_SECRET }}
           DB_DATABASE: zipp
         run: php artisan migrate --force
 
@@ -62,7 +60,7 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_PORT: 3306
           DB_USERNAME: root
-          DB_PASSWORD: root
+          DB_PASSWORD: ${{ secrets.SQL_SECRET }}
           DB_DATABASE: zipp
         run: php artisan test --no-interaction
 
@@ -86,5 +84,3 @@ jobs:
 
       - name: Build Frontend
         run: pnpm build
-
-   

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,95 @@
+name: Full workflow for laravel and react.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  laravel-node-check:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: zipp
+          MYSQL_USER: root
+          MYSQL_PASSWORD: 
+          MYSQL_ROOT_PASSWORD: 
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    steps:
+      
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2.12
+          extensions: mbstring, bcmath, mysql
+          tools: composer
+          coverage: none
+
+      - name: Install PHP Dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Copy .env
+        run: cp .env.example .env
+
+      - name: Generate app key
+        run: php artisan key:generate
+
+      - name: Run Laravel Migrations
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_USERNAME: root
+          DB_PASSWORD: 
+          DB_DATABASE: zipp
+        run: php artisan migrate --force
+
+      - name: Run Laravel Tests
+        env:
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_USERNAME: root
+          DB_PASSWORD: 
+          DB_DATABASE: zipp
+        run: php artisan test --no-interaction
+
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install Node Dependencies
+        run: pnpm install
+
+      - name: Run Lint
+        run: pnpm lint
+
+      - name: Run Prettier
+        run: pnpm prettier
+
+      - name: Build Frontend
+        run: pnpm build
+
+      
+      - name: Run Laravel Breeze Work (optional)
+        run: |
+          php artisan breeze:install blade
+          php artisan migrate --force

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           MYSQL_DATABASE: zipp
           MYSQL_USER: root
           MYSQL_PASSWORD: root
-          MYSQL_ROOT_PASSWORD: root
+          MYSQL_ROOT_PASSWORD:  ${{ secrets.SQL_SECRET }}
         ports:
           - 3306:3306
         options: >-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           DB_USERNAME: root
           DB_PASSWORD: ${{ secrets.SQL_SECRET }}
           DB_DATABASE: zipp
-        run: php artisan test --no-interaction
+        run: php artisan test 
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Full workflow for laravel and react.
+name: Full workflow for Laravel and React
 
 on:
   push:
@@ -15,8 +15,8 @@ jobs:
         env:
           MYSQL_DATABASE: zipp
           MYSQL_USER: root
-          MYSQL_PASSWORD: 
-          MYSQL_ROOT_PASSWORD: 
+          MYSQL_PASSWORD: root
+          MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
         options: >-
@@ -26,11 +26,9 @@ jobs:
           --health-retries=3
 
     steps:
-      
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -50,23 +48,24 @@ jobs:
 
       - name: Run Laravel Migrations
         env:
+          DB_CONNECTION: mysql
           DB_HOST: 127.0.0.1
           DB_PORT: 3306
           DB_USERNAME: root
-          DB_PASSWORD: 
+          DB_PASSWORD: root
           DB_DATABASE: zipp
         run: php artisan migrate --force
 
       - name: Run Laravel Tests
         env:
+          DB_CONNECTION: mysql
           DB_HOST: 127.0.0.1
           DB_PORT: 3306
           DB_USERNAME: root
-          DB_PASSWORD: 
+          DB_PASSWORD: root
           DB_DATABASE: zipp
         run: php artisan test --no-interaction
 
-      
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -88,8 +87,4 @@ jobs:
       - name: Build Frontend
         run: pnpm build
 
-      
-      - name: Run Laravel Breeze Work (optional)
-        run: |
-          php artisan breeze:install blade
-          php artisan migrate --force
+   


### PR DESCRIPTION
-  Sets up PHP 8.2.12 and installs Laravel dependencies
-  Runs Laravel database migrations and tests
-  Sets up Node.js with pnpm
-  Runs pnpm lint, prettier, and build
-  Adds support for optional Laravel Breeze install
